### PR TITLE
C program for Midas v2.1 experiment control through Kafka

### DIFF
--- a/midas_2.1/examples/experiment/Makefile
+++ b/midas_2.1/examples/experiment/Makefile
@@ -1,0 +1,144 @@
+#####################################################################
+#
+#  Name:         Makefile
+#  Created by:   Stefan Ritt
+#
+#  Contents:     Makefile for MIDAS example frontend and analyzer
+#
+#  $Id: Makefile 4647 2009-12-08 07:52:56Z ritt $
+#
+#####################################################################
+#
+#--------------------------------------------------------------------
+# The MIDASSYS should be defined prior the use of this Makefile
+ifndef MIDASSYS
+missmidas::
+	@echo "...";
+	@echo "Missing definition of environment variable 'MIDASSYS' !";
+	@echo "...";
+endif
+
+# get OS type from shell
+OSTYPE = $(shell uname)
+
+#--------------------------------------------------------------------
+# The following lines contain specific switches for different UNIX
+# systems. Find the one which matches your OS and outcomment the 
+# lines below.
+
+#-----------------------------------------
+# This is for Linux
+ifeq ($(OSTYPE),Linux)
+OSTYPE = linux
+endif
+
+ifeq ($(OSTYPE),linux)
+
+OS_DIR = linux
+OSFLAGS = -DOS_LINUX -Dextname
+CFLAGS = -g -O2 -Wall
+# add to compile in 32-bit mode
+# OSFLAGS += -m32
+LIBS = -lm -lz -lutil -lnsl -lpthread -lrt -lrdkafka -ljson-c -lyaml
+endif
+
+#-----------------------
+# MacOSX/Darwin is just a funny Linux
+#
+ifeq ($(OSTYPE),Darwin)
+OSTYPE = darwin
+endif
+
+ifeq ($(OSTYPE),darwin)
+OS_DIR = darwin
+FF = cc
+OSFLAGS = -DOS_LINUX -DOS_DARWIN -DHAVE_STRLCPY -DAbsoftUNIXFortran -fPIC -Wno-unused-function
+LIBS = -lpthread
+SPECIFIC_OS_PRG = $(BIN_DIR)/mlxspeaker
+NEED_STRLCPY=
+NEED_RANLIB=1
+NEED_SHLIB=
+NEED_RPATH=
+
+endif
+
+#-----------------------------------------
+# ROOT flags and libs
+#
+ifdef ROOTSYS
+ROOTCFLAGS := $(shell  $(ROOTSYS)/bin/root-config --cflags)
+ROOTCFLAGS += -DHAVE_ROOT -DUSE_ROOT
+ROOTLIBS   := $(shell  $(ROOTSYS)/bin/root-config --libs) -Wl,-rpath,$(ROOTSYS)/lib
+ROOTLIBS   += -lThread
+else
+missroot:
+	@echo "...";
+	@echo "Missing definition of environment variable 'ROOTSYS' !";
+	@echo "...";
+endif
+#-------------------------------------------------------------------
+# The following lines define directories. Adjust if necessary
+#                 
+DRV_DIR   = $(MIDASSYS)/drivers/kernel/khyt1331_26
+INC_DIR   = $(MIDASSYS)/include
+LIB_DIR   = $(MIDASSYS)/$(OS_DIR)/lib
+SRC_DIR   = $(MIDASSYS)/src
+
+#-------------------------------------------------------------------
+# List of analyzer modules
+#
+MODULES   = adcsum.o
+
+#-------------------------------------------------------------------
+# Hardware driver can be (camacnul, kcs2926, kcs2927, hyt1331)
+#
+DRIVER = camac
+
+#-------------------------------------------------------------------
+# Frontend code name defaulted to frontend in this example.
+# comment out the line and run your own frontend as follow:
+# gmake UFE=my_frontend
+#
+UFE = anach0fe
+
+####################################################################
+# Lines below here should not be edited
+####################################################################
+
+# MIDAS library
+LIB = $(LIB_DIR)/libmidas.a
+
+# compiler
+CC = gcc
+CXX = g++
+CFLAGS += -g -I$(INC_DIR) -I$(DRV_DIR)
+LDFLAGS +=
+
+all: $(UFE) midlibkafka kafka_control
+
+$(UFE): $(LIB) $(LIB_DIR)/mfe.o $(DRIVER).o $(UFE).c $(SRC_DIR)/cnaf_callback.c
+	$(CC) -DHAVE_CAMAC $(CFLAGS) $(OSFLAGS) -o $(UFE) $(UFE).c \
+	$(SRC_DIR)/cnaf_callback.c $(DRIVER).o  $(LIB_DIR)/mfe.o $(LIB) \
+	$(LDFEFLAGS) $(LIBS)
+
+$(DRIVER).o: $(DRV_DIR)/$(DRIVER).c
+	$(CC) $(CFLAGS) $(OSFLAGS) -c -o $(DRIVER).o $(DRV_DIR)/$(DRIVER).c
+
+midlibkafka: midlibkafka.c
+	$(CC) -c midlibkafka.c -I.
+
+analyzer: $(LIB) $(LIB_DIR)/rmana.o analyzer.o $(MODULES)
+	$(CXX) $(CFLAGS) -o $@ $(LIB_DIR)/rmana.o analyzer.o $(MODULES) \
+	$(LIB) $(LDFLAGS) $(ROOTLIBS) $(LIBS)
+
+kafka_control: $(LIB) kafka_control.c
+	$(CC) $(CFLAGS) $(OSFLAGS) -o kafka_control kafka_control.c \
+	$(LIB) $(LDFEFLAGS) $(LIBS) midlibkafka.o
+
+%.o: %.c experim.h
+	$(CXX) $(USERFLAGS) $(ROOTCFLAGS) $(CFLAGS) $(OSFLAGS) -o $@ -c $<
+
+clean::
+	rm -f *.o *~ \#*
+
+#end file

--- a/midas_2.1/examples/experiment/README.md
+++ b/midas_2.1/examples/experiment/README.md
@@ -1,0 +1,29 @@
+# Midas framework kafka control in C
+
+A C program within the [MIDAS](https://midas.triumf.ca/MidasWiki/index.php/Main_Page) framework that consumes json format control messages from a Kafka topic and produces DAQ status information to topics. 
+
+## Contents
+
+The program is based on the example experiment that ships with legacy MIDAS v2.1
+
+## Dependancies
+
+librdkafka, json-c, libyaml
+
+## Installation
+
+The associated .yaml file must include configuration information for Kafka brokers, MIDAS experiment name, host name, etc.
+
+
+Within the experiment directory do the following:
+
+```bash
+make midlibkafka  
+make kafka_control
+```
+
+```bash
+./kafka_control
+```
+
+Status messages to stderr , so pipe those to a log file

--- a/midas_2.1/examples/experiment/adccalib.c
+++ b/midas_2.1/examples/experiment/adccalib.c
@@ -1,0 +1,141 @@
+/********************************************************************\
+
+  Name:         adccalib.c
+  Created by:   Stefan Ritt
+
+  Contents:     Example analyzer module for ADC calibration. Looks
+                for ADC0 bank, subtracts pedestals and applies gain
+                calibration. The resulting values are appended to 
+                the event as an CADC bank ("calibrated ADC"). The
+                pedestal values and software gains are stored in
+                adccalib_param structure which was defined in the ODB
+                and transferred to experim.h.
+
+  $Id:$
+
+\********************************************************************/
+
+/*-- Include files -------------------------------------------------*/
+
+/* standard includes */
+#include <stdio.h>
+#include <time.h>
+
+/* midas includes */
+#include "midas.h"
+#include "rmidas.h"
+#include "experim.h"
+#include "analyzer.h"
+
+/* root includes */
+#include <TH1D.h>
+#include <TTree.h>
+
+/*-- Parameters ----------------------------------------------------*/
+
+ADC_CALIBRATION_PARAM adccalib_param;
+extern EXP_PARAM exp_param;
+extern RUNINFO runinfo;
+
+/*-- Module declaration --------------------------------------------*/
+
+INT adc_calib(EVENT_HEADER *, void *);
+INT adc_calib_init(void);
+INT adc_calib_bor(INT run_number);
+INT adc_calib_eor(INT run_number);
+
+ADC_CALIBRATION_PARAM_STR(adc_calibration_param_str);
+
+ANA_MODULE adc_calib_module = {
+   "ADC calibration",           /* module name           */
+   "Stefan Ritt",               /* author                */
+   adc_calib,                   /* event routine         */
+   adc_calib_bor,               /* BOR routine           */
+   adc_calib_eor,               /* EOR routine           */
+   adc_calib_init,              /* init routine          */
+   NULL,                        /* exit routine          */
+   &adccalib_param,             /* parameter structure   */
+   sizeof(adccalib_param),      /* structure size        */
+   adc_calibration_param_str,   /* initial parameters    */
+};
+
+/*-- module-local variables ----------------------------------------*/
+
+static TH1D *hAdcHists[N_ADC];
+
+/*-- init routine --------------------------------------------------*/
+
+#define ADC_N_BINS   500
+#define ADC_X_LOW      0
+#define ADC_X_HIGH  4000
+
+INT adc_calib_init(void)
+{
+   char name[256];
+   int i;
+
+   /* book CADC histos */
+
+   for (i = 0; i < N_ADC; i++) {
+      char title[256];
+
+      sprintf(name, "CADC%02d", i);
+      sprintf(title, "ADC %d", i);
+
+      hAdcHists[i] = h1_book<TH1D>(name, title, ADC_N_BINS, ADC_X_LOW, ADC_X_HIGH);
+   }
+
+   return SUCCESS;
+}
+
+/*-- BOR routine ---------------------------------------------------*/
+
+INT adc_calib_bor(INT run_number)
+{
+   return SUCCESS;
+}
+
+/*-- eor routine ---------------------------------------------------*/
+
+INT adc_calib_eor(INT run_number)
+{
+   return SUCCESS;
+}
+
+/*-- event routine -------------------------------------------------*/
+
+INT adc_calib(EVENT_HEADER * pheader, void *pevent)
+{
+   INT i;
+   WORD *pdata;
+   float *cadc;
+
+   /* look for ADC0 bank, return if not present */
+   if (!bk_locate(pevent, "ADC0", &pdata))
+      return 1;
+
+   /* create calibrated ADC bank */
+   bk_create(pevent, "CADC", TID_FLOAT, (void**)&cadc);
+
+   /* zero cadc bank */
+   for (i = 0; i < N_ADC; i++)
+      cadc[i] = 0.f;
+
+   /* subtract pedestal */
+   for (i = 0; i < N_ADC; i++)
+      cadc[i] = (float) ((double) pdata[i] - adccalib_param.pedestal[i] + 0.5);
+
+   /* apply software gain calibration */
+   for (i = 0; i < N_ADC; i++)
+      cadc[i] *= adccalib_param.software_gain[i];
+
+   /* fill ADC histos if above threshold */
+   for (i = 0; i < N_ADC; i++)
+      if (cadc[i] > (float) adccalib_param.histo_threshold)
+         hAdcHists[i]->Fill(cadc[i], 1);
+
+   /* close calculated bank */
+   bk_close(pevent, cadc + N_ADC);
+
+   return SUCCESS;
+}

--- a/midas_2.1/examples/experiment/adcsum.c
+++ b/midas_2.1/examples/experiment/adcsum.c
@@ -1,0 +1,127 @@
+/********************************************************************\
+
+  Name:         adcsum.c
+  Created by:   Stefan Ritt
+
+  Contents:     Example analyzer module for ADC summing. This module
+                looks for a bank named CADC and produces an ASUM
+                bank which contains the sum of all ADC values. The
+                ASUM bank is a "structured" bank. It has been defined
+                in the ODB and transferred to experim.h.
+
+  $Id:$
+
+\********************************************************************/
+
+/*-- Include files -------------------------------------------------*/
+
+/* standard includes */
+#include <stdio.h>
+#include <math.h>
+
+#define DEFINE_TESTS // must be defined prior to midas.h
+
+/* midas includes */
+#include "midas.h"
+#include "rmidas.h"
+#include "experim.h"
+#include "analyzer.h"
+
+/* root includes */
+#include <TH1D.h>
+
+#ifndef PI
+#define PI 3.14159265359
+#endif
+
+/*-- Parameters ----------------------------------------------------*/
+
+ADC_SUMMING_PARAM adc_summing_param;
+
+/*-- Tests ---------------------------------------------------------*/
+
+DEF_TEST(low_sum);
+DEF_TEST(high_sum);
+
+/*-- Module declaration --------------------------------------------*/
+
+INT adc_summing(EVENT_HEADER *, void *);
+INT adc_summing_init(void);
+INT adc_summing_bor(INT run_number);
+
+ADC_SUMMING_PARAM_STR(adc_summing_param_str);
+
+ANA_MODULE adc_summing_module = {
+   "ADC summing",               /* module name           */
+   "Stefan Ritt",               /* author                */
+   adc_summing,                 /* event routine         */
+   NULL,                        /* BOR routine           */
+   NULL,                        /* EOR routine           */
+   adc_summing_init,            /* init routine          */
+   NULL,                        /* exit routine          */
+   &adc_summing_param,          /* parameter structure   */
+   sizeof(adc_summing_param),   /* structure size        */
+   adc_summing_param_str,       /* initial parameters    */
+};
+
+/*-- Module-local variables-----------------------------------------*/
+
+static TH1D *hAdcSum, *hAdcAvg;
+
+/*-- init routine --------------------------------------------------*/
+
+INT adc_summing_init(void)
+{
+   /* book ADC sum histo */
+   hAdcSum = h1_book<TH1D>("ADCSUM", "ADC sum", 500, 0, 10000);
+
+   /* book ADC average in separate subfolder */
+   open_subfolder("Average");
+   hAdcAvg = h1_book<TH1D>("ADCAVG", "ADC average", 500000, 0, 10000);
+   close_subfolder();
+
+   return SUCCESS;
+}
+
+/*-- event routine -------------------------------------------------*/
+
+INT adc_summing(EVENT_HEADER * pheader, void *pevent)
+{
+   INT i, j, n_adc;
+   float *cadc;
+   ASUM_BANK *asum;
+
+   /* look for CADC bank, return if not present */
+   n_adc = bk_locate(pevent, "CADC", &cadc);
+   if (n_adc == 0)
+      return 1;
+
+   /* create ADC sum bank */
+   bk_create(pevent, "ASUM", TID_STRUCT, (void**)&asum);
+
+   /* sum all channels above threashold */
+   asum->sum = 0.f;
+   for (i = j = 0; i < n_adc; i++)
+      if (cadc[i] > adc_summing_param.adc_threshold) {
+         asum->sum += cadc[i];
+         j++;
+      }
+
+   /* calculate ADC average */
+   asum->average = j > 0 ? asum->sum / j : 0;
+
+   /* evaluate tests */
+   SET_TEST(low_sum, asum->sum < 1000);
+   SET_TEST(high_sum, asum->sum > 1000);
+
+   /* fill sum histo */
+   hAdcSum->Fill(asum->sum, 1);
+
+   /* fill average histo */
+   hAdcAvg->Fill(asum->average);
+
+   /* close calculated bank */
+   bk_close(pevent, asum + 1);
+
+   return SUCCESS;
+}

--- a/midas_2.1/examples/experiment/analyzer.c
+++ b/midas_2.1/examples/experiment/analyzer.c
@@ -1,0 +1,282 @@
+/********************************************************************\
+
+  Name:         analyzer.c
+  Created by:   Stefan Ritt
+
+  Contents:     System part of Analyzer code for sample experiment
+
+  $Id$
+
+\********************************************************************/
+
+/* standard includes */
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+/* midas includes */
+#include "midas.h"
+#include "experim.h"
+#include "analyzer.h"
+
+/* cernlib includes */
+#ifdef OS_WINNT
+#define VISUAL_CPLUSPLUS
+#endif
+#ifdef __linux__
+#define f2cFortran
+#endif
+
+#ifdef HAVE_HBOOK
+#include <cfortran.h>
+#include <hbook.h>
+
+PAWC_DEFINE(1000000);
+#endif                          /* HAVE_HBOOK */
+
+/*-- Globals -------------------------------------------------------*/
+
+/* The analyzer name (client name) as seen by other MIDAS clients   */
+char *analyzer_name = "Analyzer";
+
+/* analyzer_loop is called with this interval in ms (0 to disable)  */
+INT analyzer_loop_period = 0;
+
+/* default ODB size */
+INT odb_size = DEFAULT_ODB_SIZE;
+
+/* ODB structures */
+RUNINFO runinfo;
+GLOBAL_PARAM global_param;
+EXP_PARAM exp_param;
+TRIGGER_SETTINGS trigger_settings;
+
+/*-- Module declarations -------------------------------------------*/
+
+extern ANA_MODULE scaler_accum_module;
+extern ANA_MODULE adc_calib_module;
+extern ANA_MODULE adc_summing_module;
+
+ANA_MODULE *scaler_module[] = {
+   &scaler_accum_module,
+   NULL
+};
+
+ANA_MODULE *trigger_module[] = {
+   &adc_calib_module,
+   &adc_summing_module,
+   NULL
+};
+
+/*-- Bank definitions ----------------------------------------------*/
+
+ASUM_BANK_STR(asum_bank_str);
+
+BANK_LIST ana_trigger_bank_list[] = {
+
+   /* online banks */
+   {"ADC0", TID_WORD, N_ADC, NULL},
+   {"TDC0", TID_WORD, N_TDC, NULL},
+
+   /* calculated banks */
+   {"CADC", TID_FLOAT, N_ADC, NULL},
+   {"ASUM", TID_STRUCT, sizeof(ASUM_BANK), asum_bank_str},
+
+   {""},
+};
+
+BANK_LIST ana_scaler_bank_list[] = {
+   /* online banks */
+   {"SCLR", TID_DWORD, N_ADC, NULL},
+
+   /* calculated banks */
+   {"ACUM", TID_DOUBLE, N_ADC, NULL},
+   {""},
+};
+
+/*-- Event request list --------------------------------------------*/
+
+ANALYZE_REQUEST analyze_request[] = {
+   {"Trigger",                  /* equipment name */
+    {1,                         /* event ID */
+     TRIGGER_ALL,               /* trigger mask */
+     GET_NONBLOCKING,           /* get events without blocking producer */
+     "SYSTEM",                  /* event buffer */
+     TRUE,                      /* enabled */
+     "", "",}
+    ,
+    NULL,                       /* analyzer routine */
+    trigger_module,             /* module list */
+    ana_trigger_bank_list,      /* bank list */
+    1000,                       /* RWNT buffer size */
+    TRUE,                       /* Use tests for this event */
+    }
+   ,
+
+   {"Scaler",                   /* equipment name */
+    {2,                         /* event ID */
+     TRIGGER_ALL,               /* trigger mask */
+     GET_ALL,                   /* get all events */
+     "SYSTEM",                  /* event buffer */
+     TRUE,                      /* enabled */
+     "", "",}
+    ,
+    NULL,                       /* analyzer routine */
+    scaler_module,              /* module list */
+    ana_scaler_bank_list,       /* bank list */
+    100,                        /* RWNT buffer size */
+    }
+   ,
+
+   {""}
+   ,
+};
+
+/*-- Analyzer Init -------------------------------------------------*/
+
+INT analyzer_init()
+{
+   HNDLE hDB, hKey;
+   char str[80];
+
+   RUNINFO_STR(runinfo_str);
+   EXP_PARAM_STR(exp_param_str);
+   GLOBAL_PARAM_STR(global_param_str);
+   TRIGGER_SETTINGS_STR(trigger_settings_str);
+
+   /* open ODB structures */
+   cm_get_experiment_database(&hDB, NULL);
+   db_create_record(hDB, 0, "/Runinfo", strcomb((const char **)runinfo_str));
+   db_find_key(hDB, 0, "/Runinfo", &hKey);
+   if (db_open_record(hDB, hKey, &runinfo, sizeof(runinfo), MODE_READ, NULL, NULL) !=
+       DB_SUCCESS) {
+      cm_msg(MERROR, "analyzer_init", "Cannot open \"/Runinfo\" tree in ODB");
+      return 0;
+   }
+
+   db_create_record(hDB, 0, "/Experiment/Run Parameters", strcomb((const char **)exp_param_str));
+   db_find_key(hDB, 0, "/Experiment/Run Parameters", &hKey);
+   if (db_open_record(hDB, hKey, &exp_param, sizeof(exp_param), MODE_READ, NULL, NULL) !=
+       DB_SUCCESS) {
+      cm_msg(MERROR, "analyzer_init",
+             "Cannot open \"/Experiment/Run Parameters\" tree in ODB");
+      return 0;
+   }
+
+   sprintf(str, "/%s/Parameters/Global", analyzer_name);
+   db_create_record(hDB, 0, str, strcomb((const char **)global_param_str));
+   db_find_key(hDB, 0, str, &hKey);
+   if (db_open_record
+       (hDB, hKey, &global_param, sizeof(global_param), MODE_READ, NULL,
+        NULL) != DB_SUCCESS) {
+      cm_msg(MERROR, "analyzer_init", "Cannot open \"%s\" tree in ODB", str);
+      return 0;
+   }
+
+   db_create_record(hDB, 0, "/Equipment/Trigger/Settings", strcomb((const char **)trigger_settings_str));
+   db_find_key(hDB, 0, "/Equipment/Trigger/Settings", &hKey);
+
+   if (db_open_record
+       (hDB, hKey, &trigger_settings, sizeof(trigger_settings), MODE_READ, NULL,
+        NULL) != DB_SUCCESS) {
+      cm_msg(MERROR, "analyzer_init",
+             "Cannot open \"/Equipment/Trigger/Settings\" tree in ODB");
+      return 0;
+   }
+
+   return SUCCESS;
+}
+
+/*-- Analyzer Exit -------------------------------------------------*/
+
+INT analyzer_exit()
+{
+   return CM_SUCCESS;
+}
+
+/*-- Begin of Run --------------------------------------------------*/
+
+INT ana_begin_of_run(INT run_number, char *error)
+{
+   return CM_SUCCESS;
+}
+
+/*-- End of Run ----------------------------------------------------*/
+
+INT ana_end_of_run(INT run_number, char *error)
+{
+   FILE *f;
+   time_t now;
+   char str[256];
+   int size;
+   double n;
+   HNDLE hDB;
+   BOOL flag;
+
+   cm_get_experiment_database(&hDB, NULL);
+
+   /* update run log if run was written and running online */
+
+   size = sizeof(flag);
+   db_get_value(hDB, 0, "/Logger/Write data", &flag, &size, TID_BOOL, TRUE);
+   if (flag && runinfo.online_mode == 1) {
+      /* update run log */
+      size = sizeof(str);
+      str[0] = 0;
+      db_get_value(hDB, 0, "/Logger/Data Dir", str, &size, TID_STRING, TRUE);
+      if (str[0] != 0)
+         if (str[strlen(str) - 1] != DIR_SEPARATOR)
+            strcat(str, DIR_SEPARATOR_STR);
+      strcat(str, "runlog.txt");
+
+      f = fopen(str, "a");
+
+      time(&now);
+      strcpy(str, ctime(&now));
+      str[10] = 0;
+
+      fprintf(f, "%s\t%3d\t", str, runinfo.run_number);
+
+      strcpy(str, runinfo.start_time);
+      str[19] = 0;
+      fprintf(f, "%s\t", str + 11);
+
+      strcpy(str, ctime(&now));
+      str[19] = 0;
+      fprintf(f, "%s\t", str + 11);
+
+      size = sizeof(n);
+      db_get_value(hDB, 0, "/Equipment/Trigger/Statistics/Events sent", &n, &size,
+                   TID_DOUBLE, TRUE);
+
+      fprintf(f, "%5.1lfk\t", n / 1000);
+      fprintf(f, "%s\n", exp_param.comment);
+
+      fclose(f);
+   }
+
+   return CM_SUCCESS;
+}
+
+/*-- Pause Run -----------------------------------------------------*/
+
+INT ana_pause_run(INT run_number, char *error)
+{
+   return CM_SUCCESS;
+}
+
+/*-- Resume Run ----------------------------------------------------*/
+
+INT ana_resume_run(INT run_number, char *error)
+{
+   return CM_SUCCESS;
+}
+
+/*-- Analyzer Loop -------------------------------------------------*/
+
+INT analyzer_loop()
+{
+   return CM_SUCCESS;
+}
+
+/*------------------------------------------------------------------*/

--- a/midas_2.1/examples/experiment/analyzer.h
+++ b/midas_2.1/examples/experiment/analyzer.h
@@ -1,0 +1,22 @@
+/********************************************************************\
+
+  Name:         analyzer.h
+  Created by:   Stefan Ritt
+
+  Contents:     Analyzer global include file
+
+  $Id:$
+
+\********************************************************************/
+
+/*-- Parameters ----------------------------------------------------*/
+
+/* number of channels */
+#define N_ADC               4
+#define N_TDC               4
+#define N_SCLR              4
+
+/*-- Histo ID bases ------------------------------------------------*/
+
+#define ADCCALIB_ID_BASE 1000
+#define ADCSUM_ID_BASE   2000

--- a/midas_2.1/examples/experiment/experim.h
+++ b/midas_2.1/examples/experiment/experim.h
@@ -1,0 +1,216 @@
+/********************************************************************\
+
+  Name:         experim.h
+  Created by:   ODBedit program
+
+  Contents:     This file contains C structures for the "Experiment"
+                tree in the ODB and the "/Analyzer/Parameters" tree.
+
+                Additionally, it contains the "Settings" subtree for
+                all items listed under "/Equipment" as well as their
+                event definition.
+
+                It can be used by the frontend and analyzer to work
+                with these information.
+
+                All C structures are accompanied with a string represen-
+                tation which can be used in the db_create_record function
+                to setup an ODB structure which matches the C structure.
+
+  Created on:   Mon Apr 14 15:27:19 2003
+
+\********************************************************************/
+
+#define EXP_PARAM_DEFINED
+
+typedef struct {
+   char comment[80];
+} EXP_PARAM;
+
+#define EXP_PARAM_STR(_name) char *_name[] = {\
+"[.]",\
+"Comment = STRING : [80] Test",\
+"",\
+NULL }
+
+#ifndef EXCL_ADC_CALIBRATION
+
+#define ADC_CALIBRATION_PARAM_DEFINED
+
+typedef struct {
+   INT pedestal[8];
+   float software_gain[8];
+   double histo_threshold;
+} ADC_CALIBRATION_PARAM;
+
+#define ADC_CALIBRATION_PARAM_STR(_name) char *_name[] = {\
+"[.]",\
+"Pedestal = INT[8] :",\
+"[0] 174",\
+"[1] 194",\
+"[2] 176",\
+"[3] 182",\
+"[4] 185",\
+"[5] 215",\
+"[6] 202",\
+"[7] 202",\
+"Software Gain = FLOAT[8] :",\
+"[0] 1",\
+"[1] 1",\
+"[2] 1",\
+"[3] 1",\
+"[4] 1",\
+"[5] 1",\
+"[6] 1",\
+"[7] 1",\
+"Histo threshold = DOUBLE : 20",\
+"",\
+NULL }
+
+#endif
+
+#ifndef EXCL_ADC_SUMMING
+
+#define ADC_SUMMING_PARAM_DEFINED
+
+typedef struct {
+   float adc_threshold;
+} ADC_SUMMING_PARAM;
+
+#define ADC_SUMMING_PARAM_STR(_name) char *_name[] = {\
+"[.]",\
+"ADC threshold = FLOAT : 5",\
+"",\
+NULL }
+
+#endif
+
+#ifndef EXCL_GLOBAL
+
+#define GLOBAL_PARAM_DEFINED
+
+typedef struct {
+   float adc_threshold;
+} GLOBAL_PARAM;
+
+#define GLOBAL_PARAM_STR(_name) char *_name[] = {\
+"[.]",\
+"ADC Threshold = FLOAT : 5",\
+"",\
+NULL }
+
+#endif
+
+#ifndef EXCL_TRIGGER
+
+#define ASUM_BANK_DEFINED
+
+typedef struct {
+   float sum;
+   float average;
+} ASUM_BANK;
+
+#define ASUM_BANK_STR(_name) char *_name[] = {\
+"[.]",\
+"Sum = FLOAT : 0",\
+"Average = FLOAT : 0",\
+"",\
+NULL }
+
+#define TRIGGER_COMMON_DEFINED
+
+typedef struct {
+   WORD event_id;
+   WORD trigger_mask;
+   char buffer[32];
+   INT type;
+   INT source;
+   char format[8];
+   BOOL enabled;
+   INT read_on;
+   INT period;
+   double event_limit;
+   DWORD num_subevents;
+   INT log_history;
+   char frontend_host[32];
+   char frontend_name[32];
+   char frontend_file_name[256];
+} TRIGGER_COMMON;
+
+#define TRIGGER_COMMON_STR(_name) char *_name[] = {\
+"[.]",\
+"Event ID = WORD : 1",\
+"Trigger mask = WORD : 0",\
+"Buffer = STRING : [32] SYSTEM",\
+"Type = INT : 2",\
+"Source = INT : 16777215",\
+"Format = STRING : [8] MIDAS",\
+"Enabled = BOOL : y",\
+"Read on = INT : 257",\
+"Period = INT : 500",\
+"Event limit = DOUBLE : 0",\
+"Num subevents = DWORD : 0",\
+"Log history = INT : 0",\
+"Frontend host = STRING : [32] pc810",\
+"Frontend name = STRING : [32] Sample Frontend",\
+"Frontend file name = STRING : [256] C:\Midas\examples\experiment\frontend.c",\
+"",\
+NULL }
+
+#define TRIGGER_SETTINGS_DEFINED
+
+typedef struct {
+   BYTE io506;
+} TRIGGER_SETTINGS;
+
+#define TRIGGER_SETTINGS_STR(_name) char *_name[] = {\
+"[.]",\
+"IO506 = BYTE : 7",\
+"",\
+NULL }
+
+#endif
+
+#ifndef EXCL_SCALER
+
+#define SCALER_COMMON_DEFINED
+
+typedef struct {
+   WORD event_id;
+   WORD trigger_mask;
+   char buffer[32];
+   INT type;
+   INT source;
+   char format[8];
+   BOOL enabled;
+   INT read_on;
+   INT period;
+   double event_limit;
+   DWORD num_subevents;
+   INT log_history;
+   char frontend_host[32];
+   char frontend_name[32];
+   char frontend_file_name[256];
+} SCALER_COMMON;
+
+#define SCALER_COMMON_STR(_name) char *_name[] = {\
+"[.]",\
+"Event ID = WORD : 2",\
+"Trigger mask = WORD : 0",\
+"Buffer = STRING : [32] SYSTEM",\
+"Type = INT : 17",\
+"Source = INT : 0",\
+"Format = STRING : [8] MIDAS",\
+"Enabled = BOOL : y",\
+"Read on = INT : 377",\
+"Period = INT : 10000",\
+"Event limit = DOUBLE : 0",\
+"Num subevents = DWORD : 0",\
+"Log history = INT : 0",\
+"Frontend host = STRING : [32] pc810",\
+"Frontend name = STRING : [32] Sample Frontend",\
+"Frontend file name = STRING : [256] C:\Midas\examples\experiment\frontend.c",\
+"",\
+NULL }
+
+#endif

--- a/midas_2.1/examples/experiment/exptab
+++ b/midas_2.1/examples/experiment/exptab
@@ -1,0 +1,1 @@
+sampleexpt . sampleuser

--- a/midas_2.1/examples/experiment/frontend.c
+++ b/midas_2.1/examples/experiment/frontend.c
@@ -1,0 +1,356 @@
+/********************************************************************\
+
+  Name:         frontend.c
+  Created by:   Stefan Ritt
+
+  Contents:     Experiment specific readout code (user part) of
+                Midas frontend. This example simulates a "trigger
+                event" and a "scaler event" which are filled with
+                CAMAC or random data. The trigger event is filled
+                with two banks (ADC0 and TDC0), the scaler event
+                with one bank (SCLR).
+
+  $Id$
+
+\********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "midas.h"
+#include "mcstd.h"
+#include "experim.h"
+
+/* make frontend functions callable from the C framework */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-- Globals -------------------------------------------------------*/
+
+/* The frontend name (client name) as seen by other MIDAS clients   */
+char *frontend_name = "Sample Frontend";
+/* The frontend file name, don't change it */
+char *frontend_file_name = __FILE__;
+
+/* frontend_loop is called periodically if this variable is TRUE    */
+BOOL frontend_call_loop = FALSE;
+
+/* a frontend status page is displayed with this frequency in ms */
+INT display_period = 3000;
+
+/* maximum event size produced by this frontend */
+INT max_event_size = 10000;
+
+/* maximum event size for fragmented events (EQ_FRAGMENTED) */
+INT max_event_size_frag = 5 * 1024 * 1024;
+
+/* buffer size to hold events */
+INT event_buffer_size = 100 * 10000;
+
+/* number of channels */
+#define N_ADC  4
+#define N_TDC  4
+#define N_SCLR 4
+
+/* CAMAC crate and slots */
+#define CRATE      0
+#define SLOT_IO   23
+#define SLOT_ADC   1
+#define SLOT_TDC   2
+#define SLOT_SCLR  3
+
+/*-- Function declarations -----------------------------------------*/
+
+INT frontend_init();
+INT frontend_exit();
+INT begin_of_run(INT run_number, char *error);
+INT end_of_run(INT run_number, char *error);
+INT pause_run(INT run_number, char *error);
+INT resume_run(INT run_number, char *error);
+INT frontend_loop();
+
+INT read_trigger_event(char *pevent, INT off);
+INT read_scaler_event(char *pevent, INT off);
+
+void register_cnaf_callback(int debug);
+
+/*-- Equipment list ------------------------------------------------*/
+
+EQUIPMENT equipment[] = {
+
+   {"Trigger",               /* equipment name */
+    {1, 0,                   /* event ID, trigger mask */
+     "SYSTEM",               /* event buffer */
+     EQ_POLLED,              /* equipment type */
+     LAM_SOURCE(0, 0xFFFFFF),        /* event source crate 0, all stations */
+     "MIDAS",                /* format */
+     TRUE,                   /* enabled */
+     RO_RUNNING |            /* read only when running */
+     RO_ODB,                 /* and update ODB */
+     500,                    /* poll for 500ms */
+     0,                      /* stop run after this event limit */
+     0,                      /* number of sub events */
+     0,                      /* don't log history */
+     "", "", "",},
+    read_trigger_event,      /* readout routine */
+    },
+
+   {"Scaler",                /* equipment name */
+    {2, 0,                   /* event ID, trigger mask */
+     "SYSTEM",               /* event buffer */
+     EQ_PERIODIC | EQ_MANUAL_TRIG,   /* equipment type */
+     0,                      /* event source */
+     "MIDAS",                /* format */
+     TRUE,                   /* enabled */
+     RO_RUNNING | RO_TRANSITIONS |   /* read when running and on transitions */
+     RO_ODB,                 /* and update ODB */
+     10000,                  /* read every 10 sec */
+     0,                      /* stop run after this event limit */
+     0,                      /* number of sub events */
+     0,                      /* log history */
+     "", "", "",},
+    read_scaler_event,       /* readout routine */
+    },
+
+   {""}
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/********************************************************************\
+              Callback routines for system transitions
+
+  These routines are called whenever a system transition like start/
+  stop of a run occurs. The routines are called on the following
+  occations:
+
+  frontend_init:  When the frontend program is started. This routine
+                  should initialize the hardware.
+
+  frontend_exit:  When the frontend program is shut down. Can be used
+                  to releas any locked resources like memory, commu-
+                  nications ports etc.
+
+  begin_of_run:   When a new run is started. Clear scalers, open
+                  rungates, etc.
+
+  end_of_run:     Called on a request to stop a run. Can send
+                  end-of-run event and close run gates.
+
+  pause_run:      When a run is paused. Should disable trigger events.
+
+  resume_run:     When a run is resumed. Should enable trigger events.
+\********************************************************************/
+
+/*-- Frontend Init -------------------------------------------------*/
+
+INT frontend_init()
+{
+   /* hardware initialization */
+
+   cam_init();
+   cam_crate_clear(CRATE);
+   cam_crate_zinit(CRATE);
+
+   /* enable LAM in IO unit */
+   camc(CRATE, SLOT_IO, 0, 26);
+
+   /* enable LAM in crate controller */
+   cam_lam_enable(CRATE, SLOT_IO);
+
+   /* reset external LAM Flip-Flop */
+   camo(CRATE, SLOT_IO, 1, 16, 0xFF);
+   camo(CRATE, SLOT_IO, 1, 16, 0);
+
+   /* register CNAF functionality from cnaf_callback.c with debug output */
+   register_cnaf_callback(1);
+
+   /* print message and return FE_ERR_HW if frontend should not be started */
+
+   return SUCCESS;
+}
+
+/*-- Frontend Exit -------------------------------------------------*/
+
+INT frontend_exit()
+{
+   return SUCCESS;
+}
+
+/*-- Begin of Run --------------------------------------------------*/
+
+INT begin_of_run(INT run_number, char *error)
+{
+   /* put here clear scalers etc. */
+
+   return SUCCESS;
+}
+
+/*-- End of Run ----------------------------------------------------*/
+
+INT end_of_run(INT run_number, char *error)
+{
+   return SUCCESS;
+}
+
+/*-- Pause Run -----------------------------------------------------*/
+
+INT pause_run(INT run_number, char *error)
+{
+   return SUCCESS;
+}
+
+/*-- Resuem Run ----------------------------------------------------*/
+
+INT resume_run(INT run_number, char *error)
+{
+   return SUCCESS;
+}
+
+/*-- Frontend Loop -------------------------------------------------*/
+
+INT frontend_loop()
+{
+   /* if frontend_call_loop is true, this routine gets called when
+      the frontend is idle or once between every event */
+   return SUCCESS;
+}
+
+/*------------------------------------------------------------------*/
+
+/********************************************************************\
+
+  Readout routines for different events
+
+\********************************************************************/
+
+/*-- Trigger event routines ----------------------------------------*/
+
+INT poll_event(INT source, INT count, BOOL test)
+/* Polling routine for events. Returns TRUE if event
+   is available. If test equals TRUE, don't return. The test
+   flag is used to time the polling */
+{
+   int i;
+   DWORD lam;
+
+   for (i = 0; i < count; i++) {
+      cam_lam_read(LAM_SOURCE_CRATE(source), &lam);
+
+      if (lam & LAM_SOURCE_STATION(source))
+         if (!test)
+            return lam;
+   }
+
+   return 0;
+}
+
+/*-- Interrupt configuration ---------------------------------------*/
+
+INT interrupt_configure(INT cmd, INT source, POINTER_T adr)
+{
+   switch (cmd) {
+   case CMD_INTERRUPT_ENABLE:
+      break;
+   case CMD_INTERRUPT_DISABLE:
+      break;
+   case CMD_INTERRUPT_ATTACH:
+      break;
+   case CMD_INTERRUPT_DETACH:
+      break;
+   }
+   return SUCCESS;
+}
+
+/*-- Event readout -------------------------------------------------*/
+
+INT read_trigger_event(char *pevent, INT off)
+{
+   WORD *pdata, a;
+   INT q, timeout;
+
+   /* init bank structure */
+   bk_init(pevent);
+
+   /* create structured ADC0 bank */
+   bk_create(pevent, "ADC0", TID_WORD, &pdata);
+
+   /* wait for ADC conversion */
+   for (timeout = 100; timeout > 0; timeout--) {
+      camc_q(CRATE, SLOT_ADC, 0, 8, &q);
+      if (q)
+         break;
+   }
+   if (timeout == 0)
+      ss_printf(0, 10, "No ADC gate!");
+
+   /* use following code to read out real CAMAC ADC */
+   /*
+      for (a=0 ; a<N_ADC ; a++)
+      cami(CRATE, SLOT_ADC, a, 0, pdata++);
+    */
+
+   /* Use following code to "simulate" data */
+   for (a = 0; a < N_ADC; a++)
+      *pdata++ = rand() % 1024;
+
+   /* clear ADC */
+   camc(CRATE, SLOT_ADC, 0, 9);
+
+   bk_close(pevent, pdata);
+
+   /* create variable length TDC bank */
+   bk_create(pevent, "TDC0", TID_WORD, &pdata);
+
+   /* use following code to read out real CAMAC TDC */
+   /*
+      for (a=0 ; a<N_TDC ; a++)
+      cami(CRATE, SLOT_TDC, a, 0, pdata++);
+    */
+
+   /* Use following code to "simulate" data */
+   for (a = 0; a < N_TDC; a++)
+      *pdata++ = rand() % 1024;
+
+   /* clear TDC */
+   camc(CRATE, SLOT_TDC, 0, 9);
+
+   bk_close(pevent, pdata);
+
+   /* clear IO unit LAM */
+   camc(CRATE, SLOT_IO, 0, 10);
+
+   /* clear LAM in crate controller */
+   cam_lam_clear(CRATE, SLOT_IO);
+
+   /* reset external LAM Flip-Flop */
+   camo(CRATE, SLOT_IO, 1, 16, 0xFF);
+   camo(CRATE, SLOT_IO, 1, 16, 0);
+
+   ss_sleep(10);
+
+   return bk_size(pevent);
+}
+
+/*-- Scaler event --------------------------------------------------*/
+
+INT read_scaler_event(char *pevent, INT off)
+{
+   DWORD *pdata, a;
+
+   /* init bank structure */
+   bk_init(pevent);
+
+   /* create SCLR bank */
+   bk_create(pevent, "SCLR", TID_DWORD, &pdata);
+
+   /* read scaler bank */
+   for (a = 0; a < N_SCLR; a++)
+      cam24i(CRATE, SLOT_SCLR, a, 0, pdata++);
+
+   bk_close(pevent, pdata);
+
+   return bk_size(pevent);
+}

--- a/midas_2.1/examples/experiment/kafka_control.c
+++ b/midas_2.1/examples/experiment/kafka_control.c
@@ -1,0 +1,549 @@
+/********************************************************************\
+
+Name:         kafka_control.c
+Author:       Caswell Pieters
+
+Contents:     A control process that reads out kafka topics (control) and executes
+actions based on the message
+
+Created:        17 March 2020
+
+
+\********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <librdkafka/rdkafka.h>
+#include <string.h>
+#include <signal.h>
+#include "midas.h"
+#include "mcstd.h"
+#include "experim.h"
+#include <json-c/json.h>
+#include <yaml.h>
+#include <assert.h>
+#include "midlibkafka.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+const int true = 1;
+const int false = 0;
+
+/* function declarations */
+INT control_init(void);
+static int is_printable(const char *buf, size_t size);
+INT command_execute(const char *command, int new_run_number);
+INT kafka_consumer_setup();
+INT kafka_producer_setup();
+INT midas_info(char *mid_equip, char **run_state, double *evt_rate, double *kB_rate,
+                double *events, char **error, char **feedback);
+INT yaml_config_read();
+
+/* experiment database handle*/
+HNDLE hDB;
+
+static volatile sig_atomic_t run = 1;
+/*brief Signal termination of program*/
+
+static void stop_prog (int sig) {
+    run = 0;
+}
+/* json objects*/
+struct json_object *parsed_json;
+struct json_object *category;
+struct json_object *run_struct;
+struct json_object *action;
+struct json_object *run_number;
+struct json_object *date;
+
+
+/* Kafka variables */
+rd_kafka_t *rk;                                 /* Consumer instance handle */
+rd_kafka_t *rk_p;                               /* Producer instance handle */
+rd_kafka_topic_t *rkt_e;                        /*Error Topic object */
+rd_kafka_topic_t *rkt_f;                        /*FeedbackTopic object */
+rd_kafka_conf_t *conf;                          /* Temporary configuration object */
+rd_kafka_resp_err_t err;                        /* librdkafka API error code */
+char errstr[512];                               /* librdkafka API error reporting buffer */
+const char *brokers;                            /* Argument: broker list */
+const char *groupid;                            /* Argument: Consumer group id */
+char **topics;                                  /* Argument: list of topics to subscribe to */
+int topic_cnt;                                  /* Number of topics to subscribe to */
+rd_kafka_topic_partition_list_t *subscription;  /* Subscribed topics */
+char *expt_name;                                /* Experiment name */
+char *expt_host;                                /* Experiment host name */
+char *topic_control;                            /* Control topic */
+char *topic_manage;                             /* Management topic */
+const char *topic_errors;                       /* Errors topic */
+const char *topic_feedback;                     /* Feedback topic */
+char *mid_equip;                                /* Frontend equipment name */
+
+/* kafka per message callback */
+static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque) 
+{
+    if (rkmessage->err)
+        fprintf(stderr, "%% Message delivery failed: %s\n", rd_kafka_err2str(rkmessage->err));
+        else
+        {
+        fprintf(stderr, "%% Message delivered (%zd bytes, ""partition %"PRId32")\n", rkmessage->len, rkmessage->partition);
+        }
+}
+
+int main()
+{
+    /*odb information variables*/
+    double evt_rate, kB_rate, events ;
+    char *run_state, *error, *feedback;
+
+    /* Signal handler for clean shutdown */
+    signal(SIGINT, stop_prog);
+
+    if (control_init() == SUCCESS)
+    {
+        while (run) 
+        {
+            /*get some odb status updates*/
+            if (midas_info(mid_equip, &run_state, &evt_rate, &kB_rate, &events, &error, &feedback) != CM_SUCCESS)
+            {
+                cm_msg(MERROR, "main" , "Didn't get odb info" );
+                return 1;
+            }
+
+            char * feedback_msg = json_build_feedback(&run_state, &evt_rate, &kB_rate, &events, &feedback);
+            char *error_msg = json_build_errors(&error);
+
+            /* send messages to kafka */
+            produce_kafka_msg(rk_p, rkt_e, error_msg);
+            produce_kafka_msg(rk_p, rkt_f, feedback_msg);
+
+            /* Now for the consumer */
+            rd_kafka_message_t *rkm;
+
+            rkm = rd_kafka_consumer_poll(rk, 100);
+            if (!rkm)
+                continue; 
+            if (rkm->err) {
+                fprintf(stderr, "%% Consumer error: %s\n", rd_kafka_message_errstr(rkm));
+                rd_kafka_message_destroy(rkm);
+                continue;
+            }
+
+            /* Proper message. */
+            printf("Message on %s [%"PRId32"] at offset %"PRId64":\n", rd_kafka_topic_name(rkm->rkt), rkm->partition, rkm->offset);
+
+            /* Print the message key. */
+            if (rkm->key && is_printable(rkm->key, rkm->key_len))
+                printf(" Key: %.*s\n", (int)rkm->key_len, (const char *)rkm->key);
+            else if (rkm->key)
+                printf(" Key: (%d bytes)\n", (int)rkm->key_len);
+
+            /* Print the message value/payload. */
+            if (rkm->payload && is_printable(rkm->payload, rkm->len))
+            {
+                /* parse json */
+                parsed_json = json_tokener_parse((const char*)rkm->payload);
+                json_object_object_get_ex(parsed_json, "category", &category);
+                json_object_object_get_ex(parsed_json, "run", &run_struct);
+                json_object_object_get_ex(run_struct, "action", &action);
+                json_object_object_get_ex(run_struct, "run_number", &run_number);
+
+                printf("Category: %s\n", json_object_get_string(category));
+                printf("Run: %s\n", json_object_get_string(run_struct));
+                printf("Action: %s\n", json_object_get_string(action));
+                printf("Run number: %d\n", json_object_get_int(run_number));
+
+                command_execute(json_object_get_string(action), json_object_get_int(run_number));
+            }
+            else if (rkm->key)
+            {
+                printf(" Value: (%d bytes)\n", (int)rkm->len);
+            }
+
+            rd_kafka_message_destroy(rkm);
+
+            sleep(1);
+        }
+
+        kafka_shutdown(rk, rk_p, rkt_e, rkt_f);
+        cm_disconnect_experiment();
+
+        return 0;
+    }
+    else
+    {
+        cm_msg(MERROR, "main" , "Init failed" );
+        return 1;
+    }
+}
+
+/*-- Frontend Init -------------------------------------------------*/
+
+INT control_init()
+{
+    /* read yaml config file */
+    if (yaml_config_read() != CM_SUCCESS)
+    {
+        cm_msg(MERROR, "kafka_consumer_setup" , "Could not read yaml config" );
+        return 1;
+    }
+
+    /* connect to experiment */
+    int status = cm_connect_experiment(expt_host, expt_name, "Kafka_Control", NULL);
+    if (status != CM_SUCCESS)
+        return 1;
+
+    /* get handle to the ODB of the currently connected experiment */
+    if (cm_get_experiment_database(&hDB,NULL) != CM_SUCCESS)
+    {
+        cm_msg(MERROR, "control_init" , "Didn't get database handle" );
+        return 1;
+    }
+
+    /* set MIDAS watchdog parameters */
+    if (cm_set_watchdog_params (true,  0) != CM_SUCCESS)
+    {
+        cm_msg(MERROR, "control_init" , "Could not set watchdog parameters" );
+        return 1;
+    }
+
+    /* --------------Kafka consumer setup --------------------*/
+    if (kafka_consumer_setup () != CM_SUCCESS)
+    {
+        cm_msg(MERROR, "control_init" , "Could not create consumer" );
+        return 1;
+    }
+
+    /* --------------Kafka producer setup --------------------*/
+    if (kafka_producer_setup () != CM_SUCCESS)
+    {
+        cm_msg(MERROR, "control_init" , "Could not create producer" );
+        return 1;
+    }
+
+    cm_msg(MINFO,"control_init", "Control init run successfully");
+
+    return SUCCESS;
+}
+
+/*returns 1 if all bytes are printable, else 0. */
+static int is_printable (const char *buf, size_t size) 
+{
+    size_t i;
+
+    for (i = 0 ; i < size ; i++)
+        if (!isprint((int)buf[i]))
+            return 0;
+    return 1;
+}
+
+/* Execute the command from the topic message */
+INT command_execute(const char* command, int new_run_number)
+{
+    int  midas_command, debug_flag = 1;
+    char *str;
+
+    if (strcmp (command, "Start") == 0)
+        midas_command = TR_START;
+    if (strcmp (command, "Stop") == 0)
+        midas_command = TR_STOP;
+    if (strcmp (command, "Pause") == 0)
+        midas_command = TR_PAUSE;
+    if (strcmp (command, "Resume") == 0)
+        midas_command = TR_RESUME;
+
+    printf("command%s\n:", command);
+
+    if ( cm_transition(midas_command, new_run_number, str, sizeof(str), 0, debug_flag) != CM_SUCCESS)
+    {
+            // in case of error
+            printf("Error: %s\n", str);
+    }
+    return SUCCESS;
+}
+
+INT kafka_consumer_setup()
+{
+    /* specify kafka config options */
+    groupid = "rbs_control";
+    topics = &topic_control;
+    topic_cnt = 1;
+    conf = rd_kafka_conf_new();
+    int i;
+
+
+    if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        fprintf(stderr, "%s\n", errstr);
+        rd_kafka_conf_destroy(conf);
+        return 1;
+    }
+
+    if (rd_kafka_conf_set(conf, "group.id", groupid, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        fprintf(stderr, "%s\n", errstr);
+        rd_kafka_conf_destroy(conf);
+        return 1;
+    }
+
+    if (rd_kafka_conf_set(conf, "auto.offset.reset", "latest", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        fprintf(stderr, "%s\n", errstr);
+        rd_kafka_conf_destroy(conf);
+        return 1;
+    }
+
+    rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+    if (!rk)
+    {
+        fprintf(stderr, "%% Failed to create new consumer: %s\n", errstr);
+        return 1;
+    }
+
+    conf = NULL;
+    /* Configuration object is now owned, and freed by the rd_kafka_t instance. */
+
+    /* Convert the list of topics to a format suitable for librdkafka */
+    subscription = rd_kafka_topic_partition_list_new(topic_cnt);
+    for (i = 0 ; i < topic_cnt ; i++)
+        rd_kafka_topic_partition_list_add(subscription, topics[i], RD_KAFKA_PARTITION_UA);
+
+    /* Subscribe to the list of topics */
+    err = rd_kafka_subscribe(rk, subscription);
+    if (err) {
+        fprintf(stderr, "%% Failed to subscribe to %d topics: %s\n",subscription->cnt, rd_kafka_err2str(err));
+        rd_kafka_topic_partition_list_destroy(subscription);
+        rd_kafka_destroy(rk);
+        return 1;
+    }
+
+    fprintf(stderr, "%% Subscribed to %d topic(s), ""waiting for rebalance and messages...\n", subscription->cnt);
+
+    rd_kafka_topic_partition_list_destroy(subscription);
+
+    return SUCCESS;
+}
+
+INT kafka_producer_setup()
+{
+    groupid = "rbs_feedback";
+
+    /* Create Kafka client configuration place-holder*/
+    conf = rd_kafka_conf_new();
+
+    if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        fprintf(stderr, "%s\n", errstr);
+        return 1;
+    }
+
+    /* set the group id of the client*/
+    if (rd_kafka_conf_set(conf, "group.id", groupid, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        fprintf(stderr, "%s\n", errstr);
+        return 1;
+    }
+
+    /* Set the delivery report callback */
+    rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
+
+    /* Create producer instance*/
+
+    rk_p = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+    if (!rk_p)
+    {
+        fprintf(stderr, "%% Failed to create new producer: %s\n", errstr);
+        return 1;
+    }
+
+    /* Create topic objects that will be reused for each message*/
+    /*errors*/
+    rkt_e = rd_kafka_topic_new(rk_p, topic_errors, NULL);
+    if (!rkt_e)
+    {
+        fprintf(stderr, "%% Failed to create topic object: %s\n", rd_kafka_err2str(rd_kafka_last_error()));
+        rd_kafka_destroy(rk_p);
+        return 1;
+    }
+
+    /*feedback*/
+    rkt_f = rd_kafka_topic_new(rk_p, topic_feedback, NULL);
+    if (!rkt_f)
+    {
+        fprintf(stderr, "%% Failed to create topic object: %s\n", rd_kafka_err2str(rd_kafka_last_error()));
+        rd_kafka_destroy(rk_p);
+        return 1;
+    }
+
+    return SUCCESS;
+}
+
+INT midas_info(char *mid_equip, char **run_state, double *evt_rate, double *kB_rate,
+                 double *events, char **error, char **feedback)
+{
+    INT size, odb_run_state, odb_run_number;
+    double odb_events, odb_evt_rate, odb_kB_rate;
+    char event_rate_path[60], kB_rate_path[60], events_path[60];
+    
+    size=sizeof(odb_run_state);
+    db_get_value(hDB,0,"/Runinfo/State",
+                &odb_run_state,&size,TID_INT,0);
+    
+    if (odb_run_state == 1)
+        *run_state = "Stopped";
+    else if (odb_run_state == 2)
+        *run_state = "Paused";
+    else if (odb_run_state == 3)
+        *run_state = "Running";
+    else
+        *run_state = "Unknown";
+
+    size=sizeof(odb_run_number);
+    db_get_value(hDB,0,"/Runinfo/Run number",
+                &odb_run_number,&size,TID_INT,0);
+
+    sprintf(event_rate_path, "/Equipment/%s/Statistics/Events per sec.", mid_equip);
+    sprintf(kB_rate_path, "/Equipment/%s/Statistics/kBytes per sec.", mid_equip);
+    sprintf(events_path, "/Equipment/%s/Events sent", mid_equip);
+
+
+    size=sizeof(odb_events);
+    db_get_value(hDB,0,events_path,
+                &odb_events,&size,TID_DOUBLE,0);
+    *events = odb_events;
+
+    size=sizeof(odb_evt_rate);
+    db_get_value(hDB,0,event_rate_path,
+                &odb_evt_rate,&size,TID_DOUBLE,0);
+    *evt_rate = odb_evt_rate;
+
+    size=sizeof(odb_kB_rate);
+    db_get_value(hDB,0,kB_rate_path,
+                &odb_kB_rate,&size,TID_DOUBLE,0);
+    *kB_rate = odb_kB_rate;
+
+    *error = "OBD test error";
+    *feedback = "ODB test feedback";
+
+    return SUCCESS;
+}
+
+INT yaml_config_read()
+{
+    FILE *file;
+    yaml_parser_t parser;
+    yaml_event_t event;
+    int done = 0;
+    int error = 0;
+    char value[25];
+    int bootstrap_found = 0, host_found = 0, expt_found =0, control_found = 0, manage_found = 0,
+        errors_found = 0, feedback_found = 0, mid_equip_found = 0;
+
+    file = fopen("midas_kafka_control.yaml", "rb");
+    assert(file);
+
+    assert(yaml_parser_initialize(&parser));
+
+    yaml_parser_set_input_file(&parser, file);
+    
+    while (!done)
+    {
+        if (!yaml_parser_parse(&parser, &event))
+        {
+            error = 1;
+            break;
+        }
+
+        if (event.type == YAML_SCALAR_EVENT)
+        {
+            sprintf(value, "%s", event.data.scalar.value);
+            if (bootstrap_found == 1)
+            {
+                brokers = (char *)malloc(strlen(value)+1);
+                strcpy(brokers,value);
+                printf("broker value is: %s\n", brokers);
+                bootstrap_found++;
+            }
+            if (host_found == 1)
+            {
+                expt_host = (char *)malloc(strlen(value)+1);
+                strcpy(expt_host,value);
+                printf("expt_host value is: %s\n", expt_host);
+                host_found++;
+            }
+            if (expt_found == 1)
+            {
+                expt_name = (char *)malloc(strlen(value)+1);
+                strcpy(expt_name,value);
+                printf("expt_name value is: %s\n", expt_name);
+                expt_found++;
+            }
+            if (mid_equip_found == 1)
+            {
+                mid_equip = (char *)malloc(strlen(value)+1);
+                strcpy(mid_equip,value);
+                printf("feedback value is: %s\n", mid_equip);
+                mid_equip_found++;
+            }
+            if (control_found == 1)
+            {
+                topic_control = (char *)malloc(strlen(value)+1);
+                strcpy(topic_control,value);
+                printf("control value is: %s\n", topic_control);
+                control_found++;
+            }
+            if (manage_found == 1)
+            {
+                topic_manage = (char *)malloc(strlen(value)+1);
+                strcpy(topic_manage,value);
+                printf("manage value is: %s\n", topic_manage);
+                manage_found++;
+            }
+            if (errors_found == 1)
+            {
+                topic_errors = (char *)malloc(strlen(value)+1);
+                strcpy(topic_errors,value);
+                printf("error value is: %s\n", topic_errors);
+                errors_found++;
+            }
+            if (feedback_found == 1)
+            {
+                topic_feedback = (char *)malloc(strlen(value)+1);
+                strcpy(topic_feedback,value);
+                printf("feedback value is: %s\n", topic_feedback);
+                feedback_found++;
+            }
+
+            /* find kafka broker and topics, experiment name, and host name */
+            if (strcmp(value,"bootstrap_servers") == 0)
+                bootstrap_found++;
+            if (strcmp(value,"expt_name") == 0)
+                expt_found++;
+            if (strcmp(value,"expt_host") == 0)
+                host_found++;
+            if (strcmp(value,"midas_equipment") == 0)
+                mid_equip_found++;
+            if (strcmp(value,"control") == 0)
+                control_found++;
+            if (strcmp(value,"manage") == 0)
+                manage_found++;
+            if (strcmp(value,"errors") == 0)
+                errors_found++;
+            if (strcmp(value,"feedback") == 0)
+                feedback_found++;
+
+        }
+
+        done = (event.type == YAML_STREAM_END_EVENT);
+
+        yaml_event_delete(&event);
+    }
+
+    yaml_parser_delete(&parser);
+
+    assert(!fclose(file));
+
+    return SUCCESS;
+}

--- a/midas_2.1/examples/experiment/kill_daq.sh
+++ b/midas_2.1/examples/experiment/kill_daq.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+killall mlogger
+killall mhttpd
+killall frontend
+killall analyzer
+sleep 1
+
+#end file

--- a/midas_2.1/examples/experiment/makefile.nt
+++ b/midas_2.1/examples/experiment/makefile.nt
@@ -1,0 +1,58 @@
+#####################################################################
+#
+#  Name:         makefile.nt
+#  Created by:   Stefan Ritt
+#
+#  Contents:     Makefile for MIDAS example frontend and analyzer
+#                under Windows NT 
+#
+#  $Id$
+#
+#####################################################################
+
+
+#-------------------------------------------------------------------
+# The following lines define direcories. Adjust if necessary
+#                 
+MIDAS_DIR       = \midas
+INC_DIR         = $(MIDAS_DIR)\include
+DRV_DIR         = $(MIDAS_DIR)\drivers
+SRC_DIR         = $(MIDAS_DIR)\src
+LIB_DIR         = $(MIDAS_DIR)\nt\lib
+ZLIB_DIR        = $(MIDAS_DIR)\nt\lib
+ROOT_DIR        = $(ROOTSYS)
+
+#-------------------------------------------------------------------
+# List of analyzer modules
+#                 
+MODULES = adccalib.obj adcsum.obj scaler.obj
+
+####################################################################
+# Lines below here should not be edited
+####################################################################
+
+LIBRARY = $(LIB_DIR)\midas.lib
+
+# compiler
+CC = cl
+CFLAGS = /I$(INC_DIR) /I$(ROOT_DIR)/include /nologo /EHsc /D WIN32
+
+all: frontend.exe analyzer.exe
+
+frontend.exe:  $(LIBRARY) $(LIB_DIR)\mfe.obj $(SRC_DIR)\cnaf_callback.c frontend.c $(DRV_DIR)\camac\camacnul.c
+  $(CC) $(CFLAGS) /Fefrontend.exe frontend.c $(SRC_DIR)\cnaf_callback.c $(DRV_DIR)\camac\camacnul.c $(LIB_DIR)\mfe.obj $(LIBRARY) $(LIBS) wsock32.lib
+
+analyzer.exe: $(LIBRARY) rmana.obj analyzer.obj $(MODULES)
+  $(CC) /D USE_ROOT /Feanalyzer.exe rmana.obj analyzer.obj \
+    $(MODULES) libCore.lib libTree.lib libHist.lib libRint.lib $(ZLIB_DIR)\zlib.lib \
+    $(LIBRARY) $(LIBS) wsock32.lib /link /libpath:"$(ROOT_DIR)/lib"
+
+.c.obj:
+  $(CC) $(CFLAGS) /TP /c $<
+
+rmana.obj: $(SRC_DIR)\mana.c
+  $(CC) $(CFLAGS) /D USE_ROOT  /TP /c $(SRC_DIR)\mana.c /Fo"rmana.obj"
+
+clean:
+  del *.obj *.exe
+  

--- a/midas_2.1/examples/experiment/makefile.vxw
+++ b/midas_2.1/examples/experiment/makefile.vxw
@@ -1,0 +1,52 @@
+#####################################################################
+#
+#  Name:         Makefile
+#  Created by:   Stefan Ritt
+#
+#  Contents:     Makefile for MIDAS example frontend undex VxWorks
+#
+#  Revision history
+#  ------------------------------------------------------------------
+#  date         by    modification
+#  ---------    ---   -----------------------------------------------
+#  08-MAR-98    SR    created
+#
+#####################################################################
+
+#
+# Tools
+#
+CC = cc68k
+LD = ld68k
+RM = rm
+
+#
+# Midas input directories
+#                 
+INC_DIR 	= /tornado/target/h
+OBJ_DIR 	= /tornado/target/lib
+
+#
+# Compiler flags
+#
+CPU = MC68020
+CFLAGS = -m68020 -msoft-float -O -fvolatile -fno-builtin \
+-I$(INC_DIR) -I. \
+-ansi -nostdinc -DCPU=$(CPU) -g
+OSFLAGS = -DOS_VXWORKS
+
+####################################################################
+
+LIB = $(OBJ_DIR)/libmidas.a
+OBJS = frontend.o camacnul.o
+
+all: frontend.a
+
+frontend.a:  $(LIB) $(OBJ_DIR)/mfe.o $(OBJS)
+	$(LD) -o frontend.a -r $(OBJ_DIR)/mfe.o $(OBJS)
+
+.c.o:
+	$(CC) $(CFLAGS) $(OSFLAGS) -c $<
+
+clean:
+	$(RM) -f $(OBJS) *~ \#*

--- a/midas_2.1/examples/experiment/midas_kafka_control.yaml
+++ b/midas_2.1/examples/experiment/midas_kafka_control.yaml
@@ -1,0 +1,12 @@
+kafka:
+    bootstrap_servers: 196.24.232.101
+    group_id_interface: rbs_control_interface
+    group_id: rbs_control
+    expt_name: rbs_kafka
+    expt_host: kilowog.tlabs.ac.za
+    midas_equipment: CAMACTrigger0
+    topics:
+        control: rbs_midas_control
+        manage: rbs_midas_manage
+        errors: rbs_midas_errors
+        feedback: rbs_midas_feedback

--- a/midas_2.1/examples/experiment/midlibkafka.c
+++ b/midas_2.1/examples/experiment/midlibkafka.c
@@ -1,0 +1,82 @@
+#include <midlibkafka.h>
+
+char* json_build_feedback(char **run_state, double *evt_rate, double *kB_rate, double *events, char **feedback)
+{
+    /*Creating a json object*/
+    json_object * jobj = json_object_new_object();
+    json_object * jobj_2 = json_object_new_object();
+
+    json_object *jstring_cat = json_object_new_string("feedback");
+    json_object *jstring_os = json_object_new_string("test feedback");
+
+    json_object *jstring_state = json_object_new_string(*run_state);
+    json_object *jdouble_evt_rate = json_object_new_double(*evt_rate);
+    json_object *jdouble_kB_rate = json_object_new_double(*kB_rate);
+    json_object *jdouble_events = json_object_new_double(*events);
+
+    /*Form the json object*/
+    json_object_object_add(jobj_2,"run_state", jstring_state);
+    json_object_object_add(jobj_2,"evt_rate", jdouble_evt_rate);
+    json_object_object_add(jobj_2,"kB_rate", jdouble_kB_rate);
+    json_object_object_add(jobj_2,"events", jdouble_events);
+
+
+    json_object_object_add(jobj,"category", jstring_cat);
+    json_object_object_add(jobj,"daq", jobj_2);
+    json_object_object_add(jobj,"os", jstring_os);
+
+    return json_object_to_json_string(jobj);
+}
+
+char* json_build_errors(char **error)
+{
+    /*Creating a json object*/
+    json_object * jobj = json_object_new_object();
+
+    json_object *jstring_cat = json_object_new_string("errors");
+    json_object *jstring_err = json_object_new_string(*error);
+
+    /*Form the json object*/
+    json_object_object_add(jobj,"category", jstring_cat);
+    json_object_object_add(jobj,"msg", jstring_err);
+
+    return json_object_to_json_string(jobj);
+}
+
+void produce_kafka_msg(rd_kafka_t *rk_p, rd_kafka_topic_t *rkt, char *msg)
+{
+    if(rd_kafka_produce(rkt, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_COPY,  msg, strlen(msg), NULL, 0, NULL) == -1 )
+            {
+                fprintf(stderr, "%%Failed to produce top topic %s: %s\n", rd_kafka_topic_name, rd_kafka_err2str(rd_kafka_last_error()));
+                if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL)
+                rd_kafka_poll(rk_p, 1000);
+            }
+            else
+            {
+                /* fprintf(stderr, "%%Enqueued message (%zd bytes""for topic %s\n", strlen(msg), rd_kafka_topic_name(rkt)); */
+            }
+            rd_kafka_poll(rk_p, 0);   /* non-blocking */
+}
+
+void kafka_shutdown(rd_kafka_t *rk, rd_kafka_t *rk_p, rd_kafka_topic_t *rkt_e, rd_kafka_topic_t *rkt_f)
+{
+    /* Close the consumer: commit final offsets and leave the group. */
+    fprintf(stderr, "%% Closing consumer\n");
+    rd_kafka_consumer_close(rk);
+
+    /* Destroy the consumer */
+    rd_kafka_destroy(rk);
+
+    /* Wait for final messages to be delivered or fail*/
+
+    fprintf(stderr, "%% Flushing final messages..\n");
+
+    rd_kafka_flush(rk_p, 10*1000 /* wait for max 10 seconds */);
+
+    /* Destroy topic objects */
+    rd_kafka_topic_destroy(rkt_e);
+    rd_kafka_topic_destroy(rkt_f);
+
+    /* Destroy the producer instance */
+    rd_kafka_destroy(rk_p);
+}

--- a/midas_2.1/examples/experiment/midlibkafka.h
+++ b/midas_2.1/examples/experiment/midlibkafka.h
@@ -1,0 +1,15 @@
+#ifndef __MIDLIBKAFKA_H__
+#define __MIDLIBKAFKA_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <librdkafka/rdkafka.h>
+#include <string.h>
+#include <json-c/json.h>
+
+char* json_build_feedback(char **run_state, double *evt_rate, double *kB_rate, double *events, char **feedback);
+char* json_build_errors(char **error);
+void produce_kafka_msg(rd_kafka_t *rk_p, rd_kafka_topic_t *rkt, char * msg);
+void kafka_shutdown(rd_kafka_t *rk, rd_kafka_t *rk_p, rd_kafka_topic_t *rkt_e, rd_kafka_topic_t *rkt_f);
+
+#endif

--- a/midas_2.1/examples/experiment/readme.txt
+++ b/midas_2.1/examples/experiment/readme.txt
@@ -1,0 +1,91 @@
+Sample MIDAS experiment
+=======================
+
+This directory contains an example of a MIDAS experiment. It
+contains an even definition for a trigger event (ID 1) and a
+scaler event (ID 2).
+
+The frontend program generates both types of events and fills
+them with random data. The data is stored in the events in
+MIDAS bank format which is very similar to BOS/YBOS banks.
+
+The analyzer uses different "modules" to recover these banks
+from the events and analyzes them. For a detailed description
+of the analyzer concept please read
+
+http://pibeta.psi.ch/handbook/analyzer
+
+To adapt the sample experiment to a real experiment, following
+tasks have to be performed:
+
+1) Run the frontend on a computer which has direct access to
+the experiment hardware. Most likely this is a VxWorks machine
+or a PC running MS-DOS or Windows NT.
+
+2) Modify your event definition. If you want to send new banks
+of variable size from the frontend, just create them in the
+frontend readout code. If you want to send new structured
+banks (banks with fixed length containing data which can be
+described in a C-structure), create these banks with ODBEdit. 
+The definition is stored under
+
+  /equipment/trigger/variables
+  /equipment/scaler/variables
+
+To create a bank named "ANGL" which contains two values phi
+and theta, enter:
+
+[local]/> cd /equipment/trigger/variables
+[local]/Equipment/Trigger/Variables> cr key ANGL
+[local]/Equipment/Trigger/Variables> cd ANGL
+[local]/Equipment/Trigger/Variables/ANGL> cr double phi
+[local]/Equipment/Trigger/Variables/ANGL> cr double theta
+[local]/Equipment/Trigger/Variables/ANGL> event
+
+The last command propagates the changes to the file names
+event.h which then contains the C-structure for the ANGL
+bank.
+
+The bank can then be created in the frontend with following
+C-statements:
+
+ANGL_BANK *angl;
+
+  bk_create(pevent, "ANGL", TID_STRUCT, &angl);
+  angl->phi = 0;
+  angl->theta = 0;
+  bk_close(pevent, angl+1);
+
+3) Modify the analyzer to suit your needs. Read the analyzer
+description (see above) to learn how to add new modules, banks
+and parameters.
+
+To run a complete experiment, follow these steps:
+
+1) Run the frontend on your frontend computer.
+
+2) Run the analyzer and the mlogger on the backend computer.
+
+3) Set the data directory in the ODB under /logger/data dir.
+
+4) Set the logging channels under /logger/channels/... If tape
+writing is desired, set the logging channel type to "tape" and
+the filename to something like /dev/nrmt0h under UNIX or
+\\.\tape0 under Windows NT. When writing to disk, files with
+the extension .mid are created.
+
+5) Start/stop runs with the ODBEdit "start"/"stop" commands.
+
+6) Check if run00001.mid etc. is created when logging to disk
+is turned on.
+
+7) You can offline-analyze the .mid files with the same
+analyzer executable:
+
+  analyzer -i run00001.mid -o run00001.rz
+
+to produce directly a N-tuple file which can be loaded inside
+PAW with
+
+  PAW> hi/file 1 run00001.rz 8190
+

--- a/midas_2.1/examples/experiment/scaler.c
+++ b/midas_2.1/examples/experiment/scaler.c
@@ -1,0 +1,90 @@
+/********************************************************************\
+
+  Name:         scaler.c
+  Created by:   Stefan Ritt
+
+  Contents:     Example scaler analyzer module. This module looks
+                for a SCLR banks and accumulates scalers into an
+                ACUM bank.
+
+  $Id:$
+
+\********************************************************************/
+
+/*-- Include files -------------------------------------------------*/
+
+/* standard includes */
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+/* midas includes */
+#include "midas.h"
+#include "experim.h"
+#include "analyzer.h"
+
+/*-- Module declaration --------------------------------------------*/
+
+INT scaler_accum(EVENT_HEADER *, void *);
+INT scaler_clear(INT run_number);
+INT scaler_eor(INT run_number);
+
+ANA_MODULE scaler_accum_module = {
+   "Scaler accumulation",       /* module name           */
+   "Stefan Ritt",               /* author                */
+   scaler_accum,                /* event routine         */
+   scaler_clear,                /* BOR routine           */
+   scaler_eor,                  /* EOR routine           */
+   NULL,                        /* init routine          */
+   NULL,                        /* exit routine          */
+   NULL,                        /* parameter structure   */
+   0,                           /* structure size        */
+   NULL,                        /* initial parameters    */
+};
+
+/*-- accumulated scalers -------------------------------------------*/
+
+double scaler[32];
+
+/*-- BOR routine ---------------------------------------------------*/
+
+INT scaler_clear(INT run_number)
+{
+   memset(scaler, 0, sizeof(scaler));
+   return SUCCESS;
+}
+
+/*-- EOR routine ---------------------------------------------------*/
+
+INT scaler_eor(INT run_number)
+{
+   return SUCCESS;
+}
+
+/*-- event routine -------------------------------------------------*/
+
+INT scaler_accum(EVENT_HEADER * pheader, void *pevent)
+{
+   INT n, i;
+   DWORD *psclr;
+   double *pacum;
+
+   /* look for SCLR bank */
+   n = bk_locate(pevent, "SCLR", &psclr);
+   if (n == 0)
+      return 1;
+
+   /* create acummulated scaler bank */
+   bk_create(pevent, "ACUM", TID_DOUBLE, (void**)&pacum);
+
+   /* accumulate scalers */
+   for (i = 0; i < n; i++) {
+      scaler[i] += psclr[i];
+      pacum[i] = scaler[i];
+   }
+
+   /* close bank */
+   bk_close(pevent, pacum + n);
+
+   return SUCCESS;
+}

--- a/midas_2.1/examples/experiment/setup.sh
+++ b/midas_2.1/examples/experiment/setup.sh
@@ -1,0 +1,7 @@
+#!echo You must source
+
+export MIDASSYS=huh?
+export MIDAS_EXPTAB=./exptab
+export PATH=.:../../linux/bin:$PATH
+
+#end

--- a/midas_2.1/examples/experiment/start_daq.sh
+++ b/midas_2.1/examples/experiment/start_daq.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. setup.sh
+
+./kill_daq.sh
+
+odbedit -c clean
+#odbedit -c "rm /Analyzer/Trigger/Statistics"
+#odbedit -c "rm /Analyzer/Scaler/Statistics"
+
+mhttpd -p 8081 -D
+sleep 2
+xterm -e ./frontend &
+xterm -e ./analyzer &
+mlogger -D
+
+echo Please point your web browser to http://localhost:8081
+echo Or run: mozilla http://localhost:8081 &
+echo To look at live histograms, run: roody -Hlocalhost
+
+#end file

--- a/midas_2.1/examples/experiment/template.c
+++ b/midas_2.1/examples/experiment/template.c
@@ -1,0 +1,127 @@
+/*
+
+This is a template file for a standard MIDAS - PAW analyzer module.
+
+Replace all <template> tags with the name of the module (like 
+"adccalib" or "scaler") and all <TEMPLATE> tags with the uppercase
+name of them.
+
+It is assumed that the module uses parameters <template>_param, which
+appear in the ODB under /Analyzer/Parameters/<template>, a init 
+routine which books histos and an event routine. The event routine
+looks for a bank "XXXX" and creates a result bank "YYYY" (have to be 
+replaced with meaningful names).
+
+It is assumed that the result bank is a structured bank. Before it
+can be used, it has to be defined in the ODB with
+
+> cd /Equipment/Trigger/Variables
+> mkdir <YYYY>
+> cd <YYYY>
+> create float <item a>
+> create int <item b>
+> ....
+> make
+
+The "make" command generates <YYYY>_BANK in the file "experim.h", 
+which is included in all module files.
+
+The same has to be done with the module parameters:
+
+> cd /Analyzer/Parameters
+> mkdir <template>
+> cd <template>
+> create float <parameter a>
+> create int <parameter b>
+> ....
+> make
+
+The success of the operation can be checked by looking at the
+"experim.h" file.
+
+*/
+
+/********************************************************************\
+
+  Name:         <template>.c
+  Created by:   Stefan Ritt
+
+  Contents:     PiBeta Analyzer module for <template>
+
+  Revision history
+  ------------------------------------------------------------------
+  date         by    modification
+  ---------    ---   ------------------------------------------------
+  <date>       <XX>  created
+
+\********************************************************************/
+
+/*-- Include files -------------------------------------------------*/
+
+/* standard includes */
+#include <stdio.h>
+
+/* midas includes */
+#include "midas.h"
+#include "exprim.h"
+
+/*-- Parameters ----------------------------------------------------*/
+
+< TEMPLATE > _PARAM < template > _param;
+
+/*-- Static parameters ---------------------------------------------*/
+
+
+/*-- Module declaration --------------------------------------------*/
+
+INT < template > (EVENT_HEADER *, void *);
+INT < template > _init(void);
+
+<TEMPLATE > _PARAM_STR(<template > _param_str);
+
+ANA_MODULE < template > _module = {
+   "<template>",                /* module name           */
+       "<Your Name>",           /* author                */
+       <template >,             /* event routine         */
+       NULL,                    /* BOR routine           */
+       NULL,                    /* EOR routine           */
+       <template > _init,       /* init routine          */
+       NULL,                    /* exit routine          */
+       &<template > _param,     /* parameter structure   */
+       sizeof(<template > _param),      /* structure size        */
+       <template > _param_str,  /* initial parameters    */
+};
+
+/*-- init routine --------------------------------------------------*/
+
+INT < template > _init(void)
+{
+   /* book histos */
+
+   return SUCCESS;
+}
+
+/*-- event routine -------------------------------------------------*/
+
+INT < template > (EVENT_HEADER * pheader, void *pevent) {
+   int n;
+   XXXX_BANK *xxxx;
+   YYYY_BANK *yyyy;
+
+   /* look for <XXXX> bank, return if not present */
+   n = bk_locate(pevent, "XXXX", &xxxx);
+   if (n == 0)
+      return SUCCESS;
+
+   /* create calculated bank */
+   bk_create(pevent, "YYYY", TID_STRUCT, &yyyy);
+
+  /*---- perform calculations --------------------------------------*/
+
+   yyyy->x = xxxx->x * 2;
+
+  /*---- close calculated bank -------------------------------------*/
+   bk_close(pevent, yyyy + 1);
+
+   return SUCCESS;
+}


### PR DESCRIPTION
# Description
A C program built within the legacy v2.1 MIDAS framework for C frontends will contain a consumer to receive MIDAS run commands via a Kafka topic and a producer to push error and DAQ status information to a Kafka topic. Using librdkafka.

# Related Issue(s)
#1 

# Motivation and Context
This adds the ability to legacy MIDAS DAQ framework v2.1 C frontends to accept json control messages by consuming them from a Kafka topic, as well as producing status and error messages to Kafka topics.

# How Has This Been Tested?
Tested with MIDAS v 2.1 using the example experiment from the base install on an up to date Scientific Linux 6. Librdkafka , json-c and libyaml installed from the base repositories.
gcc version 4.4.7


# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [Contributing](https://github.com/dolosse/dolosse/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
